### PR TITLE
Send state refresh logs to DEBUG instead of INFO

### DIFF
--- a/custom_components/flair/climate.py
+++ b/custom_components/flair/climate.py
@@ -135,5 +135,5 @@ class FlairRoom(ClimateEntity):
 
     def update(self):
         """Update automation state."""
-        _LOGGER.info("Refreshing room state")
+        _LOGGER.debug("Refreshing room state")
         self._room.refresh()

--- a/custom_components/flair/fan.py
+++ b/custom_components/flair/fan.py
@@ -169,5 +169,5 @@ class FlairVent(FanEntity):
 
     def update(self):
         """Update automation state."""
-        _LOGGER.info("Refreshing device state")
+        _LOGGER.debug("Refreshing device state")
         self._vent.refresh()

--- a/custom_components/flair/sensor.py
+++ b/custom_components/flair/sensor.py
@@ -163,7 +163,7 @@ class FlairPuck(SensorEntity):
 
     def update(self):
         """Update automation state."""
-        _LOGGER.info("Refreshing device state")
+        _LOGGER.debug("Refreshing device state")
         self._puck.refresh()
 
 class FlairStructure(SensorEntity):
@@ -244,5 +244,5 @@ class FlairStructure(SensorEntity):
 
     def update(self):
         """Update automation state."""
-        _LOGGER.info("Refreshing puck state")
+        _LOGGER.debug("Refreshing puck state")
         self._structure.refresh()


### PR DESCRIPTION
Because update methods are called every 30s, these messages at INFO level tend to clutter the logs. I've changed them to DEBUG level.