### PR TITLE
Update name to just "Flair"

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Flair Vents",
+  "name": "Flair",
   "render_readme": true,
   "country": "US",
   "homeassistant": "2022.5.0b0"


### PR DESCRIPTION
"Flair" or "Flair Home Assistant Integration" might be more appropriate now that this integration covers more than just vents. What do you think?

![image](https://user-images.githubusercontent.com/435867/175389486-ac33e977-7b6b-4784-ab7a-9ee19acbe6ac.png)