### PR TITLE
Add support for HVAC "off" mode

### DIFF
--- a/custom_components/flair/climate.py
+++ b/custom_components/flair/climate.py
@@ -906,8 +906,8 @@ class HVAC(CoordinatorEntity, ClimateEntity):
                 attributes ={
                     "swing": value,
                 }
-                if setting == 'power':
-        attributes = {
-            "power": value
-        }
+        if setting == 'power':
+            attributes = {
+                "power": value
+            }
         return attributes

--- a/custom_components/flair/climate.py
+++ b/custom_components/flair/climate.py
@@ -807,14 +807,17 @@ class HVAC(CoordinatorEntity, ClimateEntity):
         Setting the targert temperature can only be done
         when structure state is manual and HVAC unit is on.
         """
-
         mode = HASS_HVAC_MODE_TO_FLAIR.get(hvac_mode)
-        attributes = self.set_attributes('hvac_mode', mode, False)
+        if hvac_mode == HVACMode.OFF:
+            attributes = self.set_attributes('power', mode, False)
+            self.hvac_data.attributes['power'] = mode
+        else:
+            attributes = self.set_attributes('hvac_mode', mode, False)
+            self.hvac_data.attributes['mode'] = mode
 
         if hvac_mode == HVACMode.DRY:
             await self.async_set_fan_mode(FAN_AUTO)
         await self.coordinator.client.update('hvac-units', self.hvac_data.id, attributes=attributes, relationships={})
-        self.hvac_data.attributes['mode'] = mode
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 
@@ -903,5 +906,8 @@ class HVAC(CoordinatorEntity, ClimateEntity):
                 attributes ={
                     "swing": value,
                 }
-
+                if setting == 'power':
+        attributes = {
+            "power": value
+        }
         return attributes


### PR DESCRIPTION
### Description
Flair pucks [do not support an "off" mode](https://documenter.getpostman.com/view/5353571/TzsbKTAG#4f2f09fc-d7fc-418f-a84e-e84847e97484). Instead they have a sperate setting for power:

> mode: "Heat", "Cool", "Fan", "Dry" or "Auto", depending on availability
> power: the last power state set by Flair "On" or "Off"

Home Assistant does support an "off" mode, which when set silently did nothing (except log an error if you knew to look for it). 

This PR maps the HA "off" mode to Flair's "off" power setting, so the two can play nicely.

### Testing
I performed these modifications locally on my HA install. I verified that I could set the off `mode` and the Flair puck would go off. I additionally verified that the HVAC power switch state correctly remained in sync.