### PR TITLE
Add support for setting mode when setting temperature

### DIFF
--- a/custom_components/flair/climate.py
+++ b/custom_components/flair/climate.py
@@ -12,6 +12,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.components.climate.const import (
+    ATTR_HVAC_MODE,
     FAN_AUTO,
     FAN_HIGH,
     FAN_LOW,
@@ -778,6 +779,9 @@ class HVAC(CoordinatorEntity, ClimateEntity):
 
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
+
+        if ATTR_HVAC_MODE in kwargs:
+            await self.async_set_hvac_mode(kwargs[ATTR_HVAC_MODE])
 
         temp = kwargs.get(ATTR_TEMPERATURE)
 

--- a/custom_components/flair/climate.py
+++ b/custom_components/flair/climate.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from flairaio.exceptions import FlairError
 from flairaio.model import HVACUnit, Puck, Room, Structure
 
 from homeassistant.components.climate import (
@@ -781,7 +782,11 @@ class HVAC(CoordinatorEntity, ClimateEntity):
         """Set new target temperature."""
 
         if ATTR_HVAC_MODE in kwargs:
-            await self.async_set_hvac_mode(kwargs[ATTR_HVAC_MODE])
+            hvac_mode = kwargs[ATTR_HVAC_MODE]
+            if hvac_mode in [HVACMode.OFF, HVACMode.FAN_ONLY, HVACMode.DRY]:
+                raise FlairError(f'{self.hvac_data.attributes["name"]}: Setting temperature is not supported for {hvac_mode} mode')
+            else:
+                await self.async_set_hvac_mode(hvac_mode)
 
         temp = kwargs.get(ATTR_TEMPERATURE)
 


### PR DESCRIPTION
I'm back :), sorry

### Summary

`climate.set_temperature` also exposes an `hvac_mode` optional parameter: https://www.home-assistant.io/integrations/climate/#service-climateset_temperature

Currently, that parameter is being silently ignored. Instead, I think it makes sense to delegate it properly to the existing hvac mode handling logic (when present)

FYI there are a few other optional parameters that are being ignored (`target_temp_high` and `target_temp_low`), and technically even `temperature` is optional, but I decided to keep this PR focused on just one concern.

### Testing

Modified and ran the code on my local HA instance and verified that this script now sets the mode to heat, where before it did nothing:

```
alias: Test Generic Script
sequence:
  - service: climate.set_temperature
    data:
      hvac_mode: heat
      temperature: 70
    target:
      device_id: 041996e79b6cee8367a984314f30ce73
mode: single
```