### PR TITLE
fix two blocking bugs and add API discovery diagnostic

### DIFF
--- a/custom_components/flair/__init__.py
+++ b/custom_components/flair/__init__.py
@@ -39,8 +39,9 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if entry.version == 1:
         LOGGER.warning("The current version of home-assistant-flair requires OAuth2 credentials. Please reauthorize using OAuth2 credentials (NOT OAuth1).")
         entry.async_start_reauth(hass)
+        return False
 
-    if entry.version == 2:
+    elif entry.version == 2:
         LOGGER.info("Migrating Flair config entry to version 2.1")
         # Prior to release 0.1.3, unique_id was not set when a user migrated
         # from OAuth1.0 to 2.0 via reauthentication. In this case, if not present,

--- a/custom_components/flair/binary_sensor.py
+++ b/custom_components/flair/binary_sensor.py
@@ -42,6 +42,11 @@ async def async_setup_entry(
             if structure_data.bridges:
                 for bridge_id, bridge_data in structure_data.bridges.items():
                     binary_sensors.append(Connectivity(coordinator, structure_id, bridge_id, 'bridges'))
+            # Puck V2
+            puck2s = getattr(structure_data, 'puck2s', {})
+            if puck2s:
+                for puck2_id in puck2s:
+                    binary_sensors.append(Connectivity(coordinator, structure_id, puck2_id, 'puck2s'))
 
     async_add_entities(binary_sensors)
 
@@ -71,6 +76,8 @@ class Connectivity(CoordinatorEntity, BinarySensorEntity):
             return self.structure_data.pucks[self.device_id]
         elif self.device_type == 'vents':
             return self.structure_data.vents[self.device_id]
+        elif self.device_type == 'puck2s':
+            return self.structure_data.puck2s[self.device_id]
         else:
             return self.structure_data.bridges[self.device_id]
 

--- a/custom_components/flair/binary_sensor.py
+++ b/custom_components/flair/binary_sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import Any
 
 from datetime import datetime, timedelta
-from flairaio.model import Bridge, Puck, Vent
+from flairaio.model import Bridge, Puck, Structure, Vent
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,

--- a/custom_components/flair/const.py
+++ b/custom_components/flair/const.py
@@ -153,6 +153,7 @@ TYPE_TO_MODEL = {
     "structures": "Structure",
     "rooms": "Room",
     "pucks": "Puck",
+    "puck2s": "Puck V2",
     "vents": "Vent",
     "bridges": "Bridge",
     "thermostats": "Thermostat",

--- a/custom_components/flair/coordinator.py
+++ b/custom_components/flair/coordinator.py
@@ -47,6 +47,11 @@ class FlairDataUpdateCoordinator(DataUpdateCoordinator):
             data = await self.client.get_flair_data()
             nl = '\n'
             LOGGER.debug(f'Found the following Flair structures/devices: {nl}{json.dumps(data, default=vars, indent=4)}')
+            for structure_id, structure in data.structures.items():
+                LOGGER.debug(
+                    f'Structure "{structure.attributes["name"]}" relationship keys: '
+                    f'{list(structure.relationships.keys())}'
+                )
         except FlairAuthError as error:
             raise ConfigEntryAuthFailed(error) from error
         except FlairError as error:

--- a/custom_components/flair/coordinator.py
+++ b/custom_components/flair/coordinator.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER, TIMEOUT
+from .model import Puck2
 
 
 class FlairDataUpdateCoordinator(DataUpdateCoordinator):
@@ -58,4 +59,31 @@ class FlairDataUpdateCoordinator(DataUpdateCoordinator):
             raise UpdateFailed(error) from error
         if not data.structures:
             raise UpdateFailed("No Structures found")
+
+        for structure_id, structure in data.structures.items():
+            puck2s: dict[str, Puck2] = {}
+            if 'puck2s' in structure.relationships:
+                try:
+                    raw_list = await self.client.get_related(structure, 'puck2s')
+                except Exception as err:
+                    LOGGER.warning(f'Failed to fetch puck2s for structure {structure_id}: {err}')
+                    raw_list = []
+                if raw_list:
+                    for raw in raw_list:
+                        obj = Puck2(
+                            id=raw['id'],
+                            attributes=raw['attributes'],
+                            relationships=raw['relationships'],
+                        )
+                        if not raw['attributes'].get('inactive', True):
+                            try:
+                                reading = await self.client.get_related(obj, 'current-reading')
+                                obj.current_reading = reading['attributes']
+                            except Exception:
+                                obj.current_reading = {}
+                        else:
+                            obj.current_reading = {}
+                        puck2s[raw['id']] = obj
+            structure.puck2s = puck2s
+
         return data

--- a/custom_components/flair/model.py
+++ b/custom_components/flair/model.py
@@ -1,0 +1,16 @@
+"""Local data models for Flair integration."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class Puck2:
+    """Dataclass for Flair Puck V2."""
+
+    id: str
+    attributes: dict[str, Any]
+    relationships: dict[str, Any]
+    current_reading: dict[str, Any] | None = None
+    type: str = 'puck2s'

--- a/custom_components/flair/number.py
+++ b/custom_components/flair/number.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Any
 
 from flairaio.model import Bridge, Puck, Structure
+from .model import Puck2
 
 from homeassistant.components.number import (
     NumberDeviceClass,
@@ -51,6 +52,16 @@ async def async_setup_entry(
             if structure_data.bridges:
                 for bridge_id, bridge_data in structure_data.bridges.items():
                     numbers.append(BridgeLED(coordinator, structure_id, bridge_id))
+
+            # Puck V2
+            puck2s = getattr(structure_data, 'puck2s', {})
+            if puck2s:
+                for puck2_id in puck2s:
+                    numbers.extend((
+                        Puck2LowerLimit(coordinator, structure_id, puck2_id),
+                        Puck2UpperLimit(coordinator, structure_id, puck2_id),
+                        Puck2TempCalibration(coordinator, structure_id, puck2_id),
+                    ))
 
     async_add_entities(numbers)
 
@@ -995,5 +1006,454 @@ class BridgeLED(CoordinatorEntity, NumberEntity):
 
         attributes = {
             "led-brightness": value
+        }
+        return attributes
+
+
+class Puck2LowerLimit(CoordinatorEntity, NumberEntity):
+    """Representation of Puck V2 set point lower limit."""
+
+    def __init__(self, coordinator, structure_id, puck2_id):
+        super().__init__(coordinator)
+        self.puck2_id = puck2_id
+        self.structure_id = structure_id
+
+    @property
+    def puck2_data(self) -> Puck2:
+        """Handle coordinator puck2 data."""
+
+        return self.coordinator.data.structures[self.structure_id].puck2s[self.puck2_id]
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device registry information for this entity."""
+
+        return {
+            "identifiers": {(DOMAIN, self.puck2_data.id)},
+            "name": self.puck2_data.attributes['name'],
+            "manufacturer": "Flair",
+            "model": "Puck V2",
+            "configuration_url": "https://my.flair.co/",
+        }
+
+    @property
+    def unique_id(self) -> str:
+        """Sets unique ID for this entity."""
+
+        return str(self.puck2_data.id) + '_lower_limit'
+
+    @property
+    def name(self) -> str:
+        """Return name of the entity."""
+
+        return "Set point lower limit"
+
+    @property
+    def has_entity_name(self) -> bool:
+        """Indicate that entity has name defined."""
+
+        return True
+
+    @property
+    def entity_category(self) -> EntityCategory:
+        """Set category to config."""
+
+        return EntityCategory.CONFIG
+
+    @property
+    def icon(self) -> str:
+        """Set icon."""
+
+        return 'mdi:thermometer'
+
+    @property
+    def native_value(self) -> float | None:
+        """Returns current lower limit."""
+
+        value = self.puck2_data.attributes.get('setpoint-bound-low')
+        if value is None:
+            return None
+        if self.hass.config.units is METRIC_SYSTEM:
+            return value
+        else:
+            return round(((value * (9/5)) + 32), 0)
+
+    @property
+    def native_unit_of_measurement(self) -> UnitOfTemperature:
+        """Return celsius or fahrenheit."""
+
+        if self.hass.config.units is METRIC_SYSTEM:
+            return UnitOfTemperature.CELSIUS
+        else:
+            return UnitOfTemperature.FAHRENHEIT
+
+    @property
+    def device_class(self) -> NumberDeviceClass:
+        """Return temp device class."""
+
+        return NumberDeviceClass.TEMPERATURE
+
+    @property
+    def mode(self) -> NumberMode:
+        """Return slider mode."""
+
+        return NumberMode.SLIDER
+
+    @property
+    def native_min_value(self) -> float:
+        """Return minimum allowed lower limit."""
+
+        if self.hass.config.units is METRIC_SYSTEM:
+            return 10.0
+        else:
+            return 50.0
+
+    @property
+    def native_max_value(self) -> float:
+        """Return maximum allowed lower limit."""
+
+        upper_limit = self.puck2_data.attributes.get('setpoint-bound-high', 32.0)
+        if self.hass.config.units is METRIC_SYSTEM:
+            return upper_limit
+        else:
+            return round(((upper_limit * (9/5)) + 32), 0)
+
+    @property
+    def native_step(self) -> float:
+        """Return temp stepping by 0.5 celsius or 1 fahrenheit."""
+
+        if self.hass.config.units is METRIC_SYSTEM:
+            return 0.5
+        else:
+            return 1.0
+
+    @property
+    def available(self) -> bool:
+        """Return true if puck is active and has setpoint bounds."""
+
+        if self.puck2_data.attributes['inactive']:
+            return False
+        return self.puck2_data.attributes.get('setpoint-bound-low') is not None
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the current value."""
+
+        if self.hass.config.units is METRIC_SYSTEM:
+            temp = value
+        else:
+            temp = round(((value - 32) * (5/9)), 2)
+
+        attributes = self.set_attributes(temp)
+        await self.coordinator.client.update('puck2s', self.puck2_data.id, attributes=attributes, relationships={})
+        self.puck2_data.attributes['setpoint-bound-low'] = temp
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    @staticmethod
+    def set_attributes(value: float) -> dict[str, float]:
+        """Creates attributes dictionary."""
+
+        attributes = {
+            "setpoint-bound-low": value
+        }
+        return attributes
+
+
+class Puck2UpperLimit(CoordinatorEntity, NumberEntity):
+    """Representation of Puck V2 set point upper limit."""
+
+    def __init__(self, coordinator, structure_id, puck2_id):
+        super().__init__(coordinator)
+        self.puck2_id = puck2_id
+        self.structure_id = structure_id
+
+    @property
+    def puck2_data(self) -> Puck2:
+        """Handle coordinator puck2 data."""
+
+        return self.coordinator.data.structures[self.structure_id].puck2s[self.puck2_id]
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device registry information for this entity."""
+
+        return {
+            "identifiers": {(DOMAIN, self.puck2_data.id)},
+            "name": self.puck2_data.attributes['name'],
+            "manufacturer": "Flair",
+            "model": "Puck V2",
+            "configuration_url": "https://my.flair.co/",
+        }
+
+    @property
+    def unique_id(self) -> str:
+        """Sets unique ID for this entity."""
+
+        return str(self.puck2_data.id) + '_upper_limit'
+
+    @property
+    def name(self) -> str:
+        """Return name of the entity."""
+
+        return "Set point upper limit"
+
+    @property
+    def has_entity_name(self) -> bool:
+        """Indicate that entity has name defined."""
+
+        return True
+
+    @property
+    def entity_category(self) -> EntityCategory:
+        """Set category to config."""
+
+        return EntityCategory.CONFIG
+
+    @property
+    def icon(self) -> str:
+        """Set icon."""
+
+        return 'mdi:thermometer'
+
+    @property
+    def native_value(self) -> float | None:
+        """Returns current upper limit."""
+
+        value = self.puck2_data.attributes.get('setpoint-bound-high')
+        if value is None:
+            return None
+        if self.hass.config.units is METRIC_SYSTEM:
+            return value
+        else:
+            return round(((value * (9/5)) + 32), 0)
+
+    @property
+    def native_unit_of_measurement(self) -> UnitOfTemperature:
+        """Return celsius or fahrenheit."""
+
+        if self.hass.config.units is METRIC_SYSTEM:
+            return UnitOfTemperature.CELSIUS
+        else:
+            return UnitOfTemperature.FAHRENHEIT
+
+    @property
+    def device_class(self) -> NumberDeviceClass:
+        """Return temp device class."""
+
+        return NumberDeviceClass.TEMPERATURE
+
+    @property
+    def mode(self) -> NumberMode:
+        """Return slider mode."""
+
+        return NumberMode.SLIDER
+
+    @property
+    def native_min_value(self) -> float:
+        """Return minimum allowed upper limit."""
+
+        lower_limit = self.puck2_data.attributes.get('setpoint-bound-low', 10.0)
+        if self.hass.config.units is METRIC_SYSTEM:
+            return lower_limit
+        else:
+            return round(((lower_limit * (9/5)) + 32), 0)
+
+    @property
+    def native_max_value(self) -> float:
+        """Return maximum allowed upper limit."""
+
+        if self.hass.config.units is METRIC_SYSTEM:
+            return 32.23
+        else:
+            return 90.0
+
+    @property
+    def native_step(self) -> float:
+        """Return temp stepping by 0.5 celsius or 1 fahrenheit."""
+
+        if self.hass.config.units is METRIC_SYSTEM:
+            return 0.5
+        else:
+            return 1.0
+
+    @property
+    def available(self) -> bool:
+        """Return true if puck is active and has setpoint bounds."""
+
+        if self.puck2_data.attributes['inactive']:
+            return False
+        return self.puck2_data.attributes.get('setpoint-bound-high') is not None
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the current value."""
+
+        if self.hass.config.units is METRIC_SYSTEM:
+            temp = value
+        else:
+            temp = round(((value - 32) * (5/9)), 2)
+
+        attributes = self.set_attributes(temp)
+        await self.coordinator.client.update('puck2s', self.puck2_data.id, attributes=attributes, relationships={})
+        self.puck2_data.attributes['setpoint-bound-high'] = temp
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    @staticmethod
+    def set_attributes(value: float) -> dict[str, float]:
+        """Creates attributes dictionary."""
+
+        attributes = {
+            "setpoint-bound-high": value
+        }
+        return attributes
+
+
+class Puck2TempCalibration(CoordinatorEntity, NumberEntity):
+    """Representation of Puck V2 temperature calibration."""
+
+    def __init__(self, coordinator, structure_id, puck2_id):
+        super().__init__(coordinator)
+        self.puck2_id = puck2_id
+        self.structure_id = structure_id
+
+    @property
+    def puck2_data(self) -> Puck2:
+        """Handle coordinator puck2 data."""
+
+        return self.coordinator.data.structures[self.structure_id].puck2s[self.puck2_id]
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device registry information for this entity."""
+
+        return {
+            "identifiers": {(DOMAIN, self.puck2_data.id)},
+            "name": self.puck2_data.attributes['name'],
+            "manufacturer": "Flair",
+            "model": "Puck V2",
+            "configuration_url": "https://my.flair.co/",
+        }
+
+    @property
+    def unique_id(self) -> str:
+        """Sets unique ID for this entity."""
+
+        return str(self.puck2_data.id) + '_temp_calibration'
+
+    @property
+    def name(self) -> str:
+        """Return name of the entity."""
+
+        return "Temperature calibration"
+
+    @property
+    def has_entity_name(self) -> bool:
+        """Indicate that entity has name defined."""
+
+        return True
+
+    @property
+    def entity_category(self) -> EntityCategory:
+        """Set category to config."""
+
+        return EntityCategory.CONFIG
+
+    @property
+    def icon(self) -> str:
+        """Set icon."""
+
+        return 'mdi:thermometer'
+
+    @property
+    def native_value(self) -> float | None:
+        """Returns current temp calibration."""
+
+        offset = self.puck2_data.attributes.get('temperature-offset-override-c')
+        if offset is None:
+            return None
+        temp_c = offset + 5.0
+        if self.hass.config.units is METRIC_SYSTEM:
+            return temp_c
+        else:
+            return round((temp_c * (9/5)), 0)
+
+    @property
+    def native_unit_of_measurement(self) -> UnitOfTemperature:
+        """Return celsius or fahrenheit depending on HA settings."""
+
+        if self.hass.config.units is METRIC_SYSTEM:
+            return UnitOfTemperature.CELSIUS
+        else:
+            return UnitOfTemperature.FAHRENHEIT
+
+    @property
+    def device_class(self) -> NumberDeviceClass:
+        """Return temp device class."""
+
+        return NumberDeviceClass.TEMPERATURE
+
+    @property
+    def mode(self) -> NumberMode:
+        """Return slider mode."""
+
+        return NumberMode.SLIDER
+
+    @property
+    def native_min_value(self) -> float:
+        """Return minimum allowed temp calibration."""
+
+        if self.hass.config.units is METRIC_SYSTEM:
+            return -10.0
+        else:
+            return -18.0
+
+    @property
+    def native_max_value(self) -> float:
+        """Return maximum allowed temp calibration."""
+
+        if self.hass.config.units is METRIC_SYSTEM:
+            return 5.0
+        else:
+            return 9.0
+
+    @property
+    def native_step(self) -> float:
+        """Return temp stepping by 0.5C or 1F."""
+
+        if self.hass.config.units is METRIC_SYSTEM:
+            return 0.5
+        else:
+            return 1.0
+
+    @property
+    def available(self) -> bool:
+        """Return true if puck is active and offset exists."""
+
+        if self.puck2_data.attributes['inactive']:
+            return False
+        return self.puck2_data.attributes.get('temperature-offset-override-c') is not None
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the current value."""
+
+        if self.hass.config.units is METRIC_SYSTEM:
+            ha_to_flair = value - 5.0
+        else:
+            zero_f_to_c = (-32 * (5/9)) + 5
+            value_to_c = ((value - 32) * (5/9))
+            ha_to_flair = (value_to_c - zero_f_to_c)
+
+        attributes = self.set_attributes(ha_to_flair)
+        await self.coordinator.client.update('puck2s', self.puck2_data.id, attributes=attributes, relationships={})
+        self.puck2_data.attributes['temperature-offset-override-c'] = ha_to_flair
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    @staticmethod
+    def set_attributes(value: float) -> dict[str, float]:
+        """Creates attributes dictionary."""
+
+        attributes = {
+            "temperature-offset-override-c": value
         }
         return attributes

--- a/custom_components/flair/select.py
+++ b/custom_components/flair/select.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Any
 
 from flairaio.model import Puck, Room, Structure
+from .model import Puck2
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
@@ -67,6 +68,15 @@ async def async_setup_entry(
                     selects.extend((
                         PuckBackground(coordinator, structure_id, puck_id),
                         PuckTempScale(coordinator, structure_id, puck_id),
+                    ))
+
+            # Puck V2
+            puck2s = getattr(structure_data, 'puck2s', {})
+            if puck2s:
+                for puck2_id in puck2s:
+                    selects.extend((
+                        Puck2Background(coordinator, structure_id, puck2_id),
+                        Puck2TempScale(coordinator, structure_id, puck2_id),
                     ))
 
     async_add_entities(selects)
@@ -1156,6 +1166,204 @@ class PuckTempScale(CoordinatorEntity, SelectEntity):
         attributes = self.set_attributes(ha_to_flair)
         await self.coordinator.client.update('structures', self.structure_data.id, attributes=attributes, relationships={})
         self.puck_data.attributes['temperature-scale'] = ha_to_flair
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    @staticmethod
+    def set_attributes(option: str) -> dict[str, str]:
+        """Creates attributes dictionary."""
+
+        attributes = {
+            "temperature-scale": option
+        }
+        return attributes
+
+
+class Puck2Background(CoordinatorEntity, SelectEntity):
+    """Representation of Puck V2 background color."""
+
+    def __init__(self, coordinator, structure_id, puck2_id):
+        super().__init__(coordinator)
+        self.puck2_id = puck2_id
+        self.structure_id = structure_id
+
+    @property
+    def puck2_data(self) -> Puck2:
+        """Handle coordinator puck2 data."""
+
+        return self.coordinator.data.structures[self.structure_id].puck2s[self.puck2_id]
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device registry information for this entity."""
+
+        return {
+            "identifiers": {(DOMAIN, self.puck2_data.id)},
+            "name": self.puck2_data.attributes['name'],
+            "manufacturer": "Flair",
+            "model": "Puck V2",
+            "configuration_url": "https://my.flair.co/",
+        }
+
+    @property
+    def unique_id(self) -> str:
+        """Sets unique ID for this entity."""
+
+        return str(self.puck2_data.id) + '_background_color'
+
+    @property
+    def name(self) -> str:
+        """Return name of the entity."""
+
+        return "Background color"
+
+    @property
+    def has_entity_name(self) -> bool:
+        """Indicate that entity has name defined."""
+
+        return True
+
+    @property
+    def entity_category(self) -> EntityCategory:
+        """Set category to config."""
+
+        return EntityCategory.CONFIG
+
+    @property
+    def icon(self) -> str:
+        """Set icon."""
+
+        return 'mdi:invert-colors'
+
+    @property
+    def current_option(self) -> str | None:
+        """Returns current puck background color."""
+
+        color = self.puck2_data.attributes.get('puck-display-color')
+        return color.capitalize() if color else None
+
+    @property
+    def options(self) -> list[str]:
+        """Return list of all the available puck background colors."""
+
+        return PUCK_BACKGROUND
+
+    @property
+    def available(self) -> bool:
+        """Return true if puck is active and has display color attribute."""
+
+        if self.puck2_data.attributes['inactive']:
+            return False
+        return self.puck2_data.attributes.get('puck-display-color') is not None
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+
+        ha_to_flair = option.lower()
+        attributes = self.set_attributes(ha_to_flair)
+        await self.coordinator.client.update('puck2s', self.puck2_data.id, attributes=attributes, relationships={})
+        self.puck2_data.attributes['puck-display-color'] = ha_to_flair
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    @staticmethod
+    def set_attributes(option: str) -> dict[str, str]:
+        """Creates attributes dictionary."""
+
+        attributes = {
+            "puck-display-color": option
+        }
+        return attributes
+
+
+class Puck2TempScale(CoordinatorEntity, SelectEntity):
+    """Representation of Puck V2 temperature scale selection."""
+
+    def __init__(self, coordinator, structure_id, puck2_id):
+        super().__init__(coordinator)
+        self.puck2_id = puck2_id
+        self.structure_id = structure_id
+
+    @property
+    def puck2_data(self) -> Puck2:
+        """Handle coordinator puck2 data."""
+
+        return self.coordinator.data.structures[self.structure_id].puck2s[self.puck2_id]
+
+    @property
+    def structure_data(self) -> Structure:
+        """Handle coordinator structure data."""
+
+        return self.coordinator.data.structures[self.structure_id]
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device registry information for this entity."""
+
+        return {
+            "identifiers": {(DOMAIN, self.puck2_data.id)},
+            "name": self.puck2_data.attributes['name'],
+            "manufacturer": "Flair",
+            "model": "Puck V2",
+            "configuration_url": "https://my.flair.co/",
+        }
+
+    @property
+    def unique_id(self) -> str:
+        """Sets unique ID for this entity."""
+
+        return str(self.puck2_data.id) + '_temp_scale'
+
+    @property
+    def name(self) -> str:
+        """Return name of the entity."""
+
+        return "Temperature scale"
+
+    @property
+    def has_entity_name(self) -> bool:
+        """Indicate that entity has name defined."""
+
+        return True
+
+    @property
+    def entity_category(self) -> EntityCategory:
+        """Set category to config."""
+
+        return EntityCategory.CONFIG
+
+    @property
+    def icon(self) -> str:
+        """Set icon."""
+
+        temp_scale = self.structure_data.attributes['temperature-scale']
+
+        if temp_scale == 'F':
+            return 'mdi:temperature-fahrenheit'
+        if temp_scale == 'C':
+            return 'mdi:temperature-celsius'
+        if temp_scale == 'K':
+            return 'mdi:temperature-kelvin'
+
+    @property
+    def current_option(self) -> str | None:
+        """Returns current puck temp scale."""
+
+        current_scale = self.structure_data.attributes['temperature-scale']
+        return TEMPERATURE_SCALES.get(current_scale)
+
+    @property
+    def options(self) -> list[str]:
+        """Return list of all the available temperature scales."""
+
+        return list(TEMPERATURE_SCALES.values())
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+
+        ha_to_flair = TEMP_SCALE_TO_FLAIR.get(option)
+        attributes = self.set_attributes(ha_to_flair)
+        await self.coordinator.client.update('structures', self.structure_data.id, attributes=attributes, relationships={})
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 

--- a/custom_components/flair/sensor.py
+++ b/custom_components/flair/sensor.py
@@ -87,6 +87,20 @@ async def async_setup_entry(
                 for bridge_id, bridge_data in structure_data.bridges.items():
                     sensors.append(BridgeRSSI(coordinator, structure_id, bridge_id))
 
+            # Puck V2
+            puck2s = getattr(structure_data, 'puck2s', {})
+            if puck2s:
+                for puck2_id in puck2s:
+                    sensors.extend((
+                        Puck2Temp(coordinator, structure_id, puck2_id),
+                        Puck2Humidity(coordinator, structure_id, puck2_id),
+                        Puck2Light(coordinator, structure_id, puck2_id),
+                        Puck2Voltage(coordinator, structure_id, puck2_id),
+                        Puck2RSSI(coordinator, structure_id, puck2_id),
+                        Puck2Pressure(coordinator, structure_id, puck2_id),
+                        Gateway(coordinator, structure_id, puck2_id, 'puck2s'),
+                    ))
+
     async_add_entities(sensors)
 
 
@@ -1358,6 +1372,8 @@ class Gateway(CoordinatorEntity, SensorEntity):
 
         if self.device_type == 'pucks':
             return self.structure_data.pucks[self.device_id]
+        elif self.device_type == 'puck2s':
+            return self.structure_data.puck2s[self.device_id]
         else:
             return self.structure_data.vents[self.device_id]
 
@@ -1425,17 +1441,508 @@ class Gateway(CoordinatorEntity, SensorEntity):
                 if connected_gateway_type == 'puck':
                     if gateway := self.structure_data.pucks.get(connected_gateway_id):
                         return gateway.attributes['name']
-                    # If the gateway isn't found
-                    else:
-                        return None
+                    puck2s = getattr(self.structure_data, 'puck2s', {})
+                    if gateway := puck2s.get(connected_gateway_id):
+                        return gateway.attributes['name']
+                    return None
                 elif connected_gateway_type == 'bridge':
                     if gateway := self.structure_data.bridges.get(connected_gateway_id):
                         return gateway.attributes['name']
-                    # If gateway isn't found
-                    else:
-                        return None
+                    return None
                 else:
                     return None
         else:
             return None
-        
+
+
+class Puck2Temp(CoordinatorEntity, SensorEntity):
+    """Representation of Puck V2 Temperature."""
+
+    def __init__(self, coordinator, structure_id, puck2_id):
+        super().__init__(coordinator)
+        self.puck2_id = puck2_id
+        self.structure_id = structure_id
+
+    @property
+    def puck2_data(self):
+        """Handle coordinator puck2 data."""
+
+        return self.coordinator.data.structures[self.structure_id].puck2s[self.puck2_id]
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device registry information for this entity."""
+
+        return {
+            "identifiers": {(DOMAIN, self.puck2_data.id)},
+            "name": self.puck2_data.attributes['name'],
+            "manufacturer": "Flair",
+            "model": "Puck V2",
+            "configuration_url": "https://my.flair.co/",
+        }
+
+    @property
+    def unique_id(self) -> str:
+        """Sets unique ID for this entity."""
+
+        return str(self.puck2_data.id) + '_temperature'
+
+    @property
+    def name(self) -> str:
+        """Return name of the entity."""
+
+        return "Temperature"
+
+    @property
+    def has_entity_name(self) -> bool:
+        """Indicate that entity has name defined."""
+
+        return True
+
+    @property
+    def native_value(self) -> float:
+        """Return current temperature in Celsius."""
+
+        return self.puck2_data.attributes['current-temperature-c']
+
+    @property
+    def native_unit_of_measurement(self) -> UnitOfTemperature:
+        """Return Celsius as the native unit."""
+
+        return UnitOfTemperature.CELSIUS
+
+    @property
+    def device_class(self) -> SensorDeviceClass:
+        """Return entity device class."""
+
+        return SensorDeviceClass.TEMPERATURE
+
+    @property
+    def state_class(self) -> SensorStateClass:
+        """Return the type of state class."""
+
+        return SensorStateClass.MEASUREMENT
+
+    @property
+    def available(self) -> bool:
+        """Return true if device is available."""
+
+        if not self.puck2_data.attributes['inactive']:
+            return True
+        else:
+            return False
+
+
+class Puck2Humidity(CoordinatorEntity, SensorEntity):
+    """Representation of Puck V2 Humidity."""
+
+    def __init__(self, coordinator, structure_id, puck2_id):
+        super().__init__(coordinator)
+        self.puck2_id = puck2_id
+        self.structure_id = structure_id
+
+    @property
+    def puck2_data(self):
+        """Handle coordinator puck2 data."""
+
+        return self.coordinator.data.structures[self.structure_id].puck2s[self.puck2_id]
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device registry information for this entity."""
+
+        return {
+            "identifiers": {(DOMAIN, self.puck2_data.id)},
+            "name": self.puck2_data.attributes['name'],
+            "manufacturer": "Flair",
+            "model": "Puck V2",
+            "configuration_url": "https://my.flair.co/",
+        }
+
+    @property
+    def unique_id(self) -> str:
+        """Sets unique ID for this entity."""
+
+        return str(self.puck2_data.id) + '_humidity'
+
+    @property
+    def name(self) -> str:
+        """Return name of the entity."""
+
+        return "Humidity"
+
+    @property
+    def has_entity_name(self) -> bool:
+        """Indicate that entity has name defined."""
+
+        return True
+
+    @property
+    def native_value(self) -> float:
+        """Return current humidity."""
+
+        return self.puck2_data.attributes['current-humidity']
+
+    @property
+    def native_unit_of_measurement(self) -> str:
+        """Return percent as the native unit."""
+
+        return PERCENTAGE
+
+    @property
+    def device_class(self) -> SensorDeviceClass:
+        """Return entity device class."""
+
+        return SensorDeviceClass.HUMIDITY
+
+    @property
+    def state_class(self) -> SensorStateClass:
+        """Return the type of state class."""
+
+        return SensorStateClass.MEASUREMENT
+
+    @property
+    def available(self) -> bool:
+        """Return true if device is available."""
+
+        if not self.puck2_data.attributes['inactive']:
+            return True
+        else:
+            return False
+
+
+class Puck2Light(CoordinatorEntity, SensorEntity):
+    """Representation of Puck V2 Light."""
+
+    def __init__(self, coordinator, structure_id, puck2_id):
+        super().__init__(coordinator)
+        self.puck2_id = puck2_id
+        self.structure_id = structure_id
+
+    @property
+    def puck2_data(self):
+        """Handle coordinator puck2 data."""
+
+        return self.coordinator.data.structures[self.structure_id].puck2s[self.puck2_id]
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device registry information for this entity."""
+
+        return {
+            "identifiers": {(DOMAIN, self.puck2_data.id)},
+            "name": self.puck2_data.attributes['name'],
+            "manufacturer": "Flair",
+            "model": "Puck V2",
+            "configuration_url": "https://my.flair.co/",
+        }
+
+    @property
+    def unique_id(self) -> str:
+        """Sets unique ID for this entity."""
+
+        return str(self.puck2_data.id) + '_light'
+
+    @property
+    def name(self) -> str:
+        """Return name of the entity."""
+
+        return "Light"
+
+    @property
+    def has_entity_name(self) -> bool:
+        """Indicate that entity has name defined."""
+
+        return True
+
+    @property
+    def native_value(self) -> float | None:
+        """Return current lux level."""
+
+        light = self.puck2_data.current_reading.get('light') if self.puck2_data.current_reading else None
+        if light is None:
+            return None
+        return (light / 100) * 200
+
+    @property
+    def native_unit_of_measurement(self) -> str:
+        """Return lux as the native unit."""
+
+        return LIGHT_LUX
+
+    @property
+    def device_class(self) -> SensorDeviceClass:
+        """Return entity device class."""
+
+        return SensorDeviceClass.ILLUMINANCE
+
+    @property
+    def state_class(self) -> SensorStateClass:
+        """Return the type of state class."""
+
+        return SensorStateClass.MEASUREMENT
+
+    @property
+    def available(self) -> bool:
+        """Return true if device is available and has light reading."""
+
+        if self.puck2_data.attributes['inactive']:
+            return False
+        light = self.puck2_data.current_reading.get('light') if self.puck2_data.current_reading else None
+        return light is not None
+
+
+class Puck2Voltage(CoordinatorEntity, SensorEntity):
+    """Representation of Puck V2 Voltage."""
+
+    def __init__(self, coordinator, structure_id, puck2_id):
+        super().__init__(coordinator)
+        self.puck2_id = puck2_id
+        self.structure_id = structure_id
+
+    @property
+    def puck2_data(self):
+        """Handle coordinator puck2 data."""
+
+        return self.coordinator.data.structures[self.structure_id].puck2s[self.puck2_id]
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device registry information for this entity."""
+
+        return {
+            "identifiers": {(DOMAIN, self.puck2_data.id)},
+            "name": self.puck2_data.attributes['name'],
+            "manufacturer": "Flair",
+            "model": "Puck V2",
+            "configuration_url": "https://my.flair.co/",
+        }
+
+    @property
+    def unique_id(self) -> str:
+        """Sets unique ID for this entity."""
+
+        return str(self.puck2_data.id) + '_voltage'
+
+    @property
+    def name(self) -> str:
+        """Return name of the entity."""
+
+        return "Voltage"
+
+    @property
+    def has_entity_name(self) -> bool:
+        """Indicate that entity has name defined."""
+
+        return True
+
+    @property
+    def native_value(self) -> float | None:
+        """Return voltage measurement."""
+
+        return self.puck2_data.attributes.get('voltage')
+
+    @property
+    def native_unit_of_measurement(self) -> UnitOfElectricPotential:
+        """Return volts as the native unit."""
+
+        return UnitOfElectricPotential.VOLT
+
+    @property
+    def suggested_display_precision(self) -> int:
+        """Return display precision for the voltage sensor."""
+
+        return VOLTAGE_PRECISION
+
+    @property
+    def device_class(self) -> SensorDeviceClass:
+        """Return entity device class."""
+
+        return SensorDeviceClass.VOLTAGE
+
+    @property
+    def state_class(self) -> SensorStateClass:
+        """Return the type of state class."""
+
+        return SensorStateClass.MEASUREMENT
+
+    @property
+    def entity_category(self) -> EntityCategory:
+        """Set category to diagnostic."""
+
+        return EntityCategory.DIAGNOSTIC
+
+    @property
+    def available(self) -> bool:
+        """Return true if device is available."""
+
+        if not self.puck2_data.attributes['inactive']:
+            return True
+        else:
+            return False
+
+
+class Puck2RSSI(CoordinatorEntity, SensorEntity):
+    """Representation of Puck V2 RSSI."""
+
+    def __init__(self, coordinator, structure_id, puck2_id):
+        super().__init__(coordinator)
+        self.puck2_id = puck2_id
+        self.structure_id = structure_id
+
+    @property
+    def puck2_data(self):
+        """Handle coordinator puck2 data."""
+
+        return self.coordinator.data.structures[self.structure_id].puck2s[self.puck2_id]
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device registry information for this entity."""
+
+        return {
+            "identifiers": {(DOMAIN, self.puck2_data.id)},
+            "name": self.puck2_data.attributes['name'],
+            "manufacturer": "Flair",
+            "model": "Puck V2",
+            "configuration_url": "https://my.flair.co/",
+        }
+
+    @property
+    def unique_id(self) -> str:
+        """Sets unique ID for this entity."""
+
+        return str(self.puck2_data.id) + '_rssi'
+
+    @property
+    def name(self) -> str:
+        """Return name of the entity."""
+
+        return "RSSI"
+
+    @property
+    def has_entity_name(self) -> bool:
+        """Indicate that entity has name defined."""
+
+        return True
+
+    @property
+    def native_value(self) -> float | None:
+        """Return RSSI reading."""
+
+        return self.puck2_data.attributes.get('current-rssi')
+
+    @property
+    def native_unit_of_measurement(self) -> str:
+        """Return dBm as the native unit."""
+
+        return SIGNAL_STRENGTH_DECIBELS_MILLIWATT
+
+    @property
+    def device_class(self) -> SensorDeviceClass:
+        """Return entity device class."""
+
+        return SensorDeviceClass.SIGNAL_STRENGTH
+
+    @property
+    def state_class(self) -> SensorStateClass:
+        """Return the type of state class."""
+
+        return SensorStateClass.MEASUREMENT
+
+    @property
+    def entity_category(self) -> EntityCategory:
+        """Set category to diagnostic."""
+
+        return EntityCategory.DIAGNOSTIC
+
+    @property
+    def available(self) -> bool:
+        """Return true if device is available."""
+
+        if not self.puck2_data.attributes['inactive']:
+            return True
+        else:
+            return False
+
+
+class Puck2Pressure(CoordinatorEntity, SensorEntity):
+    """Representation of Puck V2 pressure reading."""
+
+    def __init__(self, coordinator, structure_id, puck2_id):
+        super().__init__(coordinator)
+        self.puck2_id = puck2_id
+        self.structure_id = structure_id
+
+    @property
+    def puck2_data(self):
+        """Handle coordinator puck2 data."""
+
+        return self.coordinator.data.structures[self.structure_id].puck2s[self.puck2_id]
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device registry information for this entity."""
+
+        return {
+            "identifiers": {(DOMAIN, self.puck2_data.id)},
+            "name": self.puck2_data.attributes['name'],
+            "manufacturer": "Flair",
+            "model": "Puck V2",
+            "configuration_url": "https://my.flair.co/",
+        }
+
+    @property
+    def unique_id(self) -> str:
+        """Sets unique ID for this entity."""
+
+        return str(self.puck2_data.id) + '_pressure'
+
+    @property
+    def name(self) -> str:
+        """Return name of the entity."""
+
+        return "Pressure"
+
+    @property
+    def has_entity_name(self) -> bool:
+        """Indicate that entity has name defined."""
+
+        return True
+
+    @property
+    def native_value(self) -> float | None:
+        """Return pressure reading."""
+
+        if not self.puck2_data.current_reading:
+            return None
+        pressure = self.puck2_data.current_reading.get('room-pressure')
+        return round(pressure, 2) if pressure else pressure
+
+    @property
+    def native_unit_of_measurement(self) -> UnitOfPressure:
+        """Return kPa as the native unit."""
+
+        return UnitOfPressure.KPA
+
+    @property
+    def device_class(self) -> SensorDeviceClass:
+        """Return entity device class."""
+
+        return SensorDeviceClass.PRESSURE
+
+    @property
+    def state_class(self) -> SensorStateClass:
+        """Return the type of state class."""
+
+        return SensorStateClass.MEASUREMENT
+
+    @property
+    def available(self) -> bool:
+        """Return true if device is available."""
+
+        if not self.puck2_data.attributes['inactive']:
+            return True
+        else:
+            return False
+

--- a/custom_components/flair/switch.py
+++ b/custom_components/flair/switch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Any
 
 from flairaio.model import Puck, Structure
+from .model import Puck2
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
@@ -37,6 +38,14 @@ async def async_setup_entry(
                 for puck_id, puck_data in structure_data.pucks.items():
                     switches.extend((
                         PuckLock(coordinator, structure_id, puck_id),
+                    ))
+
+            # Puck V2
+            puck2s = getattr(structure_data, 'puck2s', {})
+            if puck2s:
+                for puck2_id in puck2s:
+                    switches.extend((
+                        Puck2Lock(coordinator, structure_id, puck2_id),
                     ))
 
     async_add_entities(switches)
@@ -287,5 +296,97 @@ class NetworkRepair(CoordinatorEntity, SwitchEntity):
         attributes = {"setup-mode": False}
         await self.coordinator.client.update('structures', self.structure_data.id, attributes=attributes, relationships={})
         self.structure_data.attributes['setup-mode'] = False
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+
+class Puck2Lock(CoordinatorEntity, SwitchEntity):
+    """Representation of Puck V2 lock switch."""
+
+    def __init__(self, coordinator, structure_id, puck2_id):
+        super().__init__(coordinator)
+        self.puck2_id = puck2_id
+        self.structure_id = structure_id
+
+    @property
+    def puck2_data(self) -> Puck2:
+        """Handle coordinator puck2 data."""
+
+        return self.coordinator.data.structures[self.structure_id].puck2s[self.puck2_id]
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device registry information for this entity."""
+
+        return {
+            "identifiers": {(DOMAIN, self.puck2_data.id)},
+            "name": self.puck2_data.attributes['name'],
+            "manufacturer": "Flair",
+            "model": "Puck V2",
+            "configuration_url": "https://my.flair.co/",
+        }
+
+    @property
+    def unique_id(self) -> str:
+        """Sets unique ID for this entity."""
+
+        return str(self.puck2_data.id) + '_puck_lock'
+
+    @property
+    def name(self) -> str:
+        """Return name of the entity."""
+
+        return "Lock puck"
+
+    @property
+    def has_entity_name(self) -> bool:
+        """Indicate that entity has name defined."""
+
+        return True
+
+    @property
+    def icon(self) -> str:
+        """Set icon."""
+
+        puck_locked = self.puck2_data.attributes.get('locked')
+
+        if puck_locked:
+            return 'mdi:lock'
+        else:
+            return 'mdi:lock-open-variant'
+
+    @property
+    def is_on(self) -> bool:
+        """Return if puck is locked."""
+
+        return self.puck2_data.attributes.get('locked', False)
+
+    @property
+    def available(self) -> bool:
+        """Return true if puck is active and lock setting is present."""
+
+        puck_inactive = self.puck2_data.attributes['inactive']
+        puck_locked = self.puck2_data.attributes.get('locked')
+
+        if (puck_inactive == False) and (puck_locked is not None):
+            return True
+        else:
+            return False
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Lock the puck."""
+
+        attributes = {"locked": True}
+        await self.coordinator.client.update('puck2s', self.puck2_data.id, attributes=attributes, relationships={})
+        self.puck2_data.attributes['locked'] = True
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Unlock the puck."""
+
+        attributes = {"locked": False}
+        await self.coordinator.client.update('puck2s', self.puck2_data.id, attributes=attributes, relationships={})
+        self.puck2_data.attributes['locked'] = False
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()


### PR DESCRIPTION
- binary_sensor.py: add missing Structure import (latent NameError on connectivity sensor creation)
- __init__.py: fix migration fallthrough — v1 entries now return False and use elif so v2 migration is not evaluated in the same pass
- coordinator.py: log raw structure relationship keys at DEBUG level so we can identify any new device relationship types (e.g. puck2s) that the Flair API may return for Puck V2 devices but flairaio does not fetch
